### PR TITLE
feat: support rule includes metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,13 @@ files: src/**/*.js
 Function names should use camelCase and be descriptive. Variable names should also use camelCase.
 ```
 
-### Test Coverage
+```markdown
+title: Test files required
+files: src/**/*.js
+---
+
+For every source file, there should be a corresponding test file. Check if this pattern is followed.
+```
 
 ### Rule With Shared Specification
 
@@ -161,14 +167,6 @@ includes: ../specs/CODE_GUIDE.md
 ---
 
 Confirm that this file follows the shared documentation standards defined in the included guide.
-```
-
-```markdown
-title: Test files required
-files: src/**/*.js
----
-
-For every source file, there should be a corresponding test file. Check if this pattern is followed.
 ```
 
 ## HTML Report

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Usage: autorules [options]
 Options:
   -w, --workers <number>     Number of parallel workers (default: 3)
   -r, --report <format>      Report format: html (default: html)
-  -m, --model <model>        AI model to use (default: anthropic/claude-3.5-sonnet)
+  -m, --model <model>        AI model to use (default: openai/gpt-oss-120b)
   -k, --api-key <key>        OpenRouter API key (or set OPENROUTER_API_KEY env var)
   -o, --output <path>        Output path for report (default: autorules-report.html)
   --provider <name>          Filter to only use specific provider (e.g., Cerebras)

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ my-project/
 
 ## Example Rules
 
+Each rule uses a simple frontmatter block. Alongside `title` and `files`, you can optionally provide an `includes` entry that points (relative to the rule file) to supporting guidance that should be embedded in every prompt.
+
 ### No Hardcoded Secrets
 
 ```markdown
@@ -149,6 +151,17 @@ Function names should use camelCase and be descriptive. Variable names should al
 ```
 
 ### Test Coverage
+
+### Rule With Shared Specification
+
+```markdown
+title: Must match the code guide
+files: docs/**/*.md
+includes: ../specs/CODE_GUIDE.md
+---
+
+Confirm that this file follows the shared documentation standards defined in the included guide.
+```
 
 ```markdown
 title: Test files required

--- a/example/autorules/test-includes.md
+++ b/example/autorules/test-includes.md
@@ -1,0 +1,8 @@
+title: Must match the code guide
+files: files/*.md
+includes: ../specs/CODE_GUIDE.md
+---
+
+This file must adhere to the code guide specified.
+
+Does it adhere to the code guide?

--- a/example/specs/CODE_GUIDE.md
+++ b/example/specs/CODE_GUIDE.md
@@ -1,0 +1,7 @@
+# Code Guide
+
+All code must follow these standards:
+
+- Use semicolons at the end of statements
+- Use tabs for indentation
+- Functions should be documented with JSDoc comments

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -5,6 +5,7 @@ import { glob } from "glob";
 export interface AutoRule {
 	title: string;
 	files: string;
+	includes?: string;
 	criteria: string;
 	rulePath: string;
 }
@@ -21,7 +22,7 @@ function parseFrontmatter(content: string): {
 	metadata: Record<string, string>;
 	body: string;
 } {
-	const frontmatterRegex = /^(title: .+\nfiles: .+\n)---\n([\s\S]+)$/;
+	const frontmatterRegex = /^([\s\S]*?)---\n([\s\S]+)$/;
 	const match = content.match(frontmatterRegex);
 
 	if (!match) {
@@ -37,8 +38,12 @@ function parseFrontmatter(content: string): {
 		.trim()
 		.split("\n")
 		.forEach((line) => {
-			const [key, ...valueParts] = line.split(":");
-			metadata[key.trim()] = valueParts.join(":").trim();
+			const colonIndex = line.indexOf(":");
+			if (colonIndex > 0) {
+				const key = line.substring(0, colonIndex).trim();
+				const value = line.substring(colonIndex + 1).trim();
+				metadata[key] = value;
+			}
 		});
 
 	return { metadata, body: body.trim() };
@@ -91,6 +96,7 @@ export async function loadAutoRules(
 			rules.push({
 				title: metadata.title || "Untitled Rule",
 				files: metadata.files || "**/*",
+				includes: metadata.includes,
 				criteria: body,
 				rulePath,
 			});

--- a/src/summarizer.ts
+++ b/src/summarizer.ts
@@ -1,8 +1,5 @@
 import { createThread, OpenRouter } from "@markwylde/ailib";
-import {
-	buildModelOptions,
-	type ProviderSortOption,
-} from "./modelOptions.js";
+import { buildModelOptions, type ProviderSortOption } from "./modelOptions.js";
 import type { AutoRule } from "./scanner.js";
 import type { TaskQueue } from "./taskQueue.js";
 import type { CheckResult } from "./worker.js";
@@ -38,7 +35,14 @@ export async function generateSingleRuleSummary(
 	providerSort?: ProviderSortOption,
 ): Promise<RuleSummary> {
 	return taskQueue.enqueue(async () => {
-		return await _generateSummary(ruleResults, rule, apiKey, model, providerOnly, providerSort);
+		return await _generateSummary(
+			ruleResults,
+			rule,
+			apiKey,
+			model,
+			providerOnly,
+			providerSort,
+		);
 	});
 }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -89,9 +89,9 @@ If there are causes for concern, list exactly what part failed and why you concl
 		);
 
 		// Create AI thread
-		const ai = createThread({
-			provider: OpenRouter,
-			model: options.model || "anthropic/claude-3.5-sonnet",
+			const ai = createThread({
+				provider: OpenRouter,
+				model: options.model || "openai/gpt-oss-120b",
 			messages: [{ role: "user", content: prompt }],
 			apiKey: options.apiKey,
 			...(modelOptions && { modelOptions }),

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -89,9 +89,9 @@ If there are causes for concern, list exactly what part failed and why you concl
 		);
 
 		// Create AI thread
-			const ai = createThread({
-				provider: OpenRouter,
-				model: options.model || "openai/gpt-oss-120b",
+		const ai = createThread({
+			provider: OpenRouter,
+			model: options.model || "openai/gpt-oss-120b",
 			messages: [{ role: "user", content: prompt }],
 			apiKey: options.apiKey,
 			...(modelOptions && { modelOptions }),

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,10 +1,7 @@
 import { readFile } from "node:fs/promises";
-import { relative } from "node:path";
+import { dirname, relative, resolve } from "node:path";
 import { createThread, OpenRouter } from "@markwylde/ailib";
-import {
-	buildModelOptions,
-	type ProviderSortOption,
-} from "./modelOptions.js";
+import { buildModelOptions, type ProviderSortOption } from "./modelOptions.js";
 import type { FileToCheck } from "./scanner.js";
 import type { TaskQueue } from "./taskQueue.js";
 
@@ -41,6 +38,30 @@ export async function checkFile(
 		// Read the file content
 		const content = await readFile(path, "utf-8");
 
+		// Read included file if specified
+		let includesContent = "";
+		if (rule.includes) {
+			try {
+				const ruleDir = dirname(rule.rulePath);
+				const includesPath = resolve(ruleDir, rule.includes);
+				const includesFileContent = await readFile(includesPath, "utf-8");
+				includesContent = `File: ${rule.includes}
+Content:
+\`\`\`
+${includesFileContent}
+\`\`\`
+
+---
+
+`;
+			} catch (error) {
+				// If the includes file cannot be read, continue without it
+				console.warn(
+					`Warning: Could not read includes file ${rule.includes}: ${error instanceof Error ? error.message : String(error)}`,
+				);
+			}
+		}
+
 		// Build the prompt
 		const prompt = `FILENAME: ${relativePath}
 CONTENT: application/text
@@ -54,7 +75,7 @@ You have been chosen to analyse \`${relativePath}\`.
 
 The criteria you are to assess the file on is:
 
-> ${rule.criteria}
+${includesContent}> ${rule.criteria}
 
 Your response will not get directly sent to the user, but instead will be combined with the responses of every other files generated.
 


### PR DESCRIPTION
## Summary
- add optional rule includes metadata and surface reference files in worker prompts
- improve per-rule progress tracking in the TUI and refresh CLI model defaults
- document the includes metadata usage and update default model references in README

## Testing
- not run (not requested)
