### PR TITLE
feat: track summary usage metrics

### DIFF
--- a/src/summarizer.ts
+++ b/src/summarizer.ts
@@ -10,6 +10,8 @@ export interface RuleSummary {
 	totalChecked: number;
 	passed: number;
 	failed: number;
+	tokens?: number;
+	cost?: number;
 }
 
 // ANSI color codes
@@ -102,11 +104,16 @@ Write it in markdown.
 		stream.on("error", (error) => reject(error));
 	});
 
+	// Get the last message for token/cost info
+	const lastMessage = ai.messages.list[ai.messages.list.length - 1];
+
 	return {
 		rule,
 		summary: summary.trim(),
 		totalChecked: ruleResults.length,
 		passed,
 		failed,
+		tokens: lastMessage.tokens,
+		cost: lastMessage.totalCost,
 	};
 }

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -214,6 +214,15 @@ export function createTUIState(
  */
 export function addSummary(state: TUIState, summary: RuleSummary): void {
 	state.summaries.set(summary.rule.title, summary);
+
+	// Add summary tokens and cost to totals
+	if (summary.tokens) {
+		state.totalTokens += summary.tokens;
+	}
+	if (summary.cost) {
+		state.totalCost += summary.cost;
+	}
+
 	renderTUI(state);
 }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -128,7 +128,7 @@ If there are causes for concern, list exactly what part failed and why you concl
 			passed,
 			response: response.trim(),
 			tokens: lastMessage.tokens,
-			cost: lastMessage.cost,
+			cost: lastMessage.totalCost,
 		};
 	} catch (error) {
 		return {


### PR DESCRIPTION
## Summary
- capture tokens and cost details in summaries and roll them into TUI totals
- correct worker cost reporting to use the total cost returned by the provider

## Testing
- `npm test` *(fails: Error: no test specified)*
